### PR TITLE
Soften dependencies

### DIFF
--- a/lib/sidekiq_retry_monitor/version.rb
+++ b/lib/sidekiq_retry_monitor/version.rb
@@ -1,3 +1,3 @@
 module SidekiqRetryMonitor
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/sidekiq_retry_monitor.gemspec
+++ b/sidekiq_retry_monitor.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_dependency 'rollbar', '~> 2.0'
+  spec.add_dependency 'rollbar'
 end


### PR DESCRIPTION
So I can upgrade to rollbar gem 3.0, the breaking change was dropping ruby 2.6. 

And the exact bundler version doesn’t really matter. 

[#175768996]